### PR TITLE
Change command to git remotes

### DIFF
--- a/src/Dandelion/VersionControl/Git.php
+++ b/src/Dandelion/VersionControl/Git.php
@@ -207,7 +207,7 @@ class Git implements GitInterface
         $process = $this->processFactory->create($command);
 
         $process->run();
-
+        var_dump(implode(" ", $command));
         if (!$process->isSuccessful()) {
             throw new RuntimeException($process->getExitCodeText(), $process->getExitCode());
         }
@@ -250,9 +250,9 @@ class Git implements GitInterface
     {
         $command = [
             'git',
-            'remote',
-            'show',
-            $remote
+            'config',
+            '--get',
+            sprintf('remote.%s.url', $remote)
         ];
 
         try {

--- a/src/Dandelion/VersionControl/Git.php
+++ b/src/Dandelion/VersionControl/Git.php
@@ -207,7 +207,7 @@ class Git implements GitInterface
         $process = $this->processFactory->create($command);
 
         $process->run();
-        var_dump(implode(" ", $command));
+        
         if (!$process->isSuccessful()) {
             throw new RuntimeException($process->getExitCodeText(), $process->getExitCode());
         }

--- a/tests/Dandelion/VersionControl/GitTest.php
+++ b/tests/Dandelion/VersionControl/GitTest.php
@@ -611,9 +611,9 @@ class GitTest extends Unit
             ->method('create')
             ->with([
                 'git',
-                'remote',
-                'show',
-                $remote
+                'config',
+                '--get',
+                sprintf('remote.%s.url', $remote)
             ])
             ->willReturn($this->processMock);
 
@@ -642,9 +642,9 @@ class GitTest extends Unit
             ->method('create')
             ->with([
                 'git',
-                'remote',
-                'show',
-                $remote
+                'config',
+                '--get',
+                sprintf('remote.%s.url', $remote)
             ])
             ->willReturn($this->processMock);
 


### PR DESCRIPTION
`git config` will return a better result when testing for existence of a git remote. The return code will be 0 and 1 instead of 0 and 127. 